### PR TITLE
fixed 'View on GitHub' btn link

### DIFF
--- a/apps/docs/src/index.md
+++ b/apps/docs/src/index.md
@@ -17,7 +17,7 @@ hero:
       link: /docs/quick-start
     - theme: alt
       text: View on GitHub
-      link: https://github.com/eddiesjs/eddies
+      link: https://github.com/malezjaa/eddies
 
 features:
   - icon: 🛠️


### PR DESCRIPTION
## Checklist

- [x] Docs have been added / updated (for bug fixes / features)
- [ ] The code has been formatted

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Formatting
- [ ] Refactoring
- [ ] Tests
- [ ] Other, please describe:

## What did you implement:

<!-- Describe the feature / bug fix you've implemented. -->
Fixed the redirection of 'View on GitHub' button on home page (https://malezjaa.github.io/eddies/).

## What was the previous behavior:

<!-- Describe the previous behavior. -->
On the home page https://malezjaa.github.io/eddies/ There's a button called View on GitHub

![image](https://github.com/malezjaa/eddies/assets/83546692/2322601a-33ef-4955-83d2-c73f8074d62d)

this is redirecting to a user who clicks on it to https://github.com/eddiesjs/eddies

which I think no more exists.

![image](https://github.com/malezjaa/eddies/assets/83546692/0552d97e-8f21-4f50-b268-cee1edf11afc)

So, i think this fixes the bug/wrong redirection.

## How did you implement it:

<!-- Describe the technical implementation details. -->
Searched for the old/broken link on the GitHub repository and found the file and made changes to it.

## Other changes:

<!-- Describe any minor or "drive-by" changes made in this PR. -->
Nothing.

## Related issue(s):

<!-- If this PR closes any issue(s), please reference them here. -->
